### PR TITLE
Fix bug 'Drawer shows wrong selected number'

### DIFF
--- a/imports/ui/components/QuantitySelection.jsx
+++ b/imports/ui/components/QuantitySelection.jsx
@@ -22,7 +22,8 @@ class QuantitySelection extends React.Component {
 
   toggleDrawer() {
     this.setState(prevState => ({
-      isDrawerOpen: !prevState.isDrawerOpen
+      isDrawerOpen: !prevState.isDrawerOpen,
+      selectedQuantity: this.props.itemsToReturnToSeller
     }));
   }
 


### PR DESCRIPTION
What was wrong:
1. user selects the quantity (2) in the drawer and clicks 'Apply changes'
2. user opens the drawer again, selects the quantity (5) and closes the drawer without clicking 'Apply changes'; 
3. user opens the drawer again and sees that quantity number 5 is marked as checked when in reality he didn't end up choosing 5.

It was fixed to 'user opens the drawer again and sees that quantity number 2 is marked as checked'.
