### PR TITLE
Add prop-types dependency

### DIFF
--- a/imports/ui/components/QuantitySelection.jsx
+++ b/imports/ui/components/QuantitySelection.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { addItemToReturnList } from '../actions/actions.jsx';
-import Drawer from 'react-motion-drawer';
+import Drawer from 'react-motion-drawer'; // this library causes 2 warnings to appear in the console
 import { store } from '../../../imports/startup/client/index.js'
 import QuantitySelectionRow from './QuantitySelectionRow';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,11 +2518,34 @@
       }
     },
     "prop-types": {
-      "version": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+        "fbjs": "0.8.16",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "promise": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+          }
+        }
       }
     },
     "pseudomap": {
@@ -2553,7 +2576,7 @@
         "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
         "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+        "prop-types": "15.6.0"
       }
     },
     "react-addons-css-transition-group": {
@@ -2577,7 +2600,7 @@
         "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
         "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+        "prop-types": "15.6.0"
       }
     },
     "react-hammerjs": {
@@ -2595,7 +2618,7 @@
       "requires": {
         "create-react-class": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
         "performance-now": "0.2.0",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "prop-types": "15.6.0",
         "raf": "3.3.2"
       }
     },
@@ -2620,7 +2643,7 @@
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
         "lodash-es": "4.17.4",
         "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+        "prop-types": "15.6.0"
       }
     },
     "react-router": {
@@ -2632,7 +2655,7 @@
         "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
         "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
         "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "prop-types": "15.6.0",
         "warning": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
       }
     },
@@ -2643,7 +2666,7 @@
         "history": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
         "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
         "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "prop-types": "15.6.0",
         "react-router": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
         "warning": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
       }
@@ -2655,7 +2678,7 @@
         "chain-function": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
         "dom-helpers": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
         "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "prop-types": "15.6.0",
         "warning": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
       }
     },
@@ -2667,7 +2690,7 @@
         "lodash.isfunction": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
         "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
         "lodash.tonumber": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "prop-types": "15.6.0",
         "reactstrap-tether": "https://registry.npmjs.org/reactstrap-tether/-/reactstrap-tether-1.3.4.tgz"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,17 +17,18 @@
     "jquery": ">=3.0.0",
     "meteor-node-stubs": "0.2.4",
     "popper.js": "^1.11.0",
+    "prop-types": "^15.6.0",
     "react": "^15.6.1",
     "react-addons-css-transition-group": "15.6.0",
     "react-addons-transition-group": "15.6.0",
     "react-dom": "^15.6.1",
     "react-motion-drawer": "^2.1.5",
     "react-redux": "^5.0.6",
-    "redux": "^3.0.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-transition-group": "^1.1.2",
-    "reactstrap": "^4.8.0"
+    "reactstrap": "^4.8.0",
+    "redux": "^3.0.0"
   },
   "devDependencies": {
     "autoprefixer": "7.1.2",


### PR DESCRIPTION
Could not get rid of the 2 warnings in the console (abut React class and PropTypes), because they are caused by 'react-motion-drawer' library.